### PR TITLE
Add create-new flow and make access control async

### DIFF
--- a/data/db.json
+++ b/data/db.json
@@ -59,23 +59,21 @@
           "relation": "veiwer"
         }
       ],
-    
       "folder:admin": [
         {
           "subjectId": "user:magnus",
           "relation": "owner"
         }
       ],
-      "folder:sdsf": [
-        {
-          "subjectId": "user:magnus",
-          "relation": "owner"
-        }
-      ],
-  
       "folder:tester": [
         {
           "subjectId": "user:admin",
+          "relation": "owner"
+        }
+      ],
+      "file:test": [
+        {
+          "subjectId": "user:magnus",
           "relation": "owner"
         }
       ]
@@ -92,7 +90,7 @@
         },
         {
           "relation": "owner",
-          "objectId": "folder:sdsf"
+          "objectId": "file:test"
         }
       ],
       "user:jeff": [
@@ -112,8 +110,6 @@
         }
       ],
       "user:admin": [
-
-  
         {
           "relation": "owner",
           "objectId": "folder:tester"

--- a/src/app.js
+++ b/src/app.js
@@ -268,6 +268,37 @@ app.get("/files", async (req, res) => {
   }
 });
 
+app.post("/api/createNew", async (req, res) => {
+  let currentUser;
+  try {
+    currentUser = getUser(req);
+  } catch (err) {
+    console.error(err);
+    return res.status(401).send({ message: "User not authenticated" });
+  }
+
+  const { objectId } = req.body;
+  const objectType = objectId.split(":")[0];
+
+  if (
+    objectType === "folder" ||
+    objectType === "file" ||
+    objectType === "group"
+  ) {
+    await db.read();
+    if (Object.hasOwn(db.data.tupleStore.byObject, objectId)) {
+      return res
+        .status(409)
+        .send({ message: "An object with this ID already exists." });
+    } else {
+      await accessControl.addTuple(currentUser.id, "owner", objectId);
+      return res.status(201).send({ message: "Object created successfully!" });
+    }
+  } else {
+    return res.status(400).send({ message: "Not a valid object type" });
+  }
+});
+
 app.post("/api/newTuple", async (req, res) => {
   let currentUser;
   try {
@@ -311,7 +342,7 @@ app.post("/api/newTuple", async (req, res) => {
   }
 
   try {
-    accessControl.addTuple(subjectId, relation, objectId);
+    await accessControl.addTuple(subjectId, relation, objectId);
   } catch (error) {
     await db.read(); // Ensure we have the latest state
     const tupleExistsAfterAttempt = db.data.tupleStore.byObject[objectId]?.some(
@@ -349,7 +380,7 @@ app.post("/api/deleteTuple", async (req, res) => {
   }
 
   for (const rel of relations) {
-    accessControl.deleteTuple(subjectId, rel, objectId);
+    await accessControl.deleteTuple(subjectId, rel, objectId);
   }
 
   return res.json({ success: true });
@@ -361,26 +392,6 @@ app.get("/api/userNames", (req, res) => {
     return user.name.charAt(0).toUpperCase() + user.name.slice(1);
   });
   res.send({ userNames: userNames });
-});
-
-// Create a new folder
-app.post("/api/newFolder", async (req, res) => {
-  let currentUser;
-  try {
-    currentUser = getUser(req);
-  } catch (err) {
-    return res.status(401).send({ message: "User not authenticated" });
-  }
-
-  const { folderName } = req.body;
-
-  if (!folderName) {
-    return res.status(400).send({ message: "Folder name is required" });
-  }
-
-  accessControl.addTuple(currentUser.id, "owner", `folder:${folderName}`);
-
-  res.status(201).send({ message: "Folder created successfully" });
 });
 
 // return the list of files for the provided userId if user is admin

--- a/src/public/css/dashboard.css
+++ b/src/public/css/dashboard.css
@@ -230,15 +230,8 @@ dialog::backdrop {
   margin: 1rem;
 }
 
-.modal-body button {
+button {
   cursor: pointer;
-}
-
-.modal-body #cancel-modal {
-  background-color: transparent;
-  color: var(--on-surface-variant);
-  border: 0px;
-  text-decoration: underline;
 }
 
 .invite-container {
@@ -299,6 +292,7 @@ dialog::backdrop {
   width: 100vw;
   pointer-events: none;
 }
+
 .modal-container.show {
   pointer-events: auto;
   opacity: 1;
@@ -313,6 +307,7 @@ dialog::backdrop {
   max-width: 100%;
   text-align: center;
 }
+
 #folder-name-input {
   background-color: rgb(255, 255, 255);
   border-radius: 5px;
@@ -324,4 +319,56 @@ dialog::backdrop {
   display: flex;
   justify-content: space-between;
   margin-top: 20px;
+}
+
+.create-new-modal {
+  display: grid;
+  gap: 1rem;
+  width: 40vw;
+}
+
+.create-new-modal h2 {
+  font-size: 2rem;
+  color: var(--primary-container);
+}
+
+#create-new-form {
+  display: grid;
+  gap: 1rem;
+  grid-template-areas:
+    "input-cn input-cn input-cn select-cn"
+    "buttons-cn buttons-cn buttons-cn buttons-cn";
+}
+
+#create-new-form select {
+  grid-area: select-cn;
+  border-radius: var(--radius-lg);
+  background-color: #ecf0f1;
+  border: 0px solid;
+  text-align: center;
+  font-weight: 500;
+  font-size: 1rem;
+}
+
+#create-new-form input {
+  padding: 1rem;
+  border: 0px solid;
+  background-color: #ecf0f1;
+  border-radius: 8px;
+  grid-area: input-cn;
+  font-size: 1rem;
+}
+
+.create-new-buttons {
+  margin-top: 2rem;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-area: buttons-cn;
+}
+
+.cancel-modal {
+  background-color: transparent !important;
+  color: var(--on-surface-variant) !important;
+  border: 0px;
+  text-decoration: underline;
 }

--- a/src/public/js/dashboard.js
+++ b/src/public/js/dashboard.js
@@ -1,4 +1,5 @@
 import { renderHeader } from "./navRenderer.js";
+import { validateString } from "./utils.js";
 
 renderHeader();
 
@@ -35,6 +36,50 @@ const getCurrentUser = async () => {
 document.addEventListener("DOMContentLoaded", async () => {
   const currentUser = await getCurrentUser();
   console.log("Current User: ", currentUser);
+
+  const createNewModal = document.getElementById("create-new");
+  const createNewForm = document.getElementById("create-new-form");
+  const createNewErrorMsg = document.getElementById("create-new-error");
+  const uploadNewBtn = document.getElementById("UploadNewbtn");
+  uploadNewBtn.addEventListener("click", () => {
+    createNewErrorMsg.innerText = "";
+    createNewModal.showModal();
+  });
+
+  const createNewCancelBtn = document.getElementById("create-new-cancel");
+  createNewCancelBtn.addEventListener("click", (e) => {
+    e.preventDefault();
+    createNewModal.close();
+    createNewForm.reset();
+  });
+
+  const createNewButton = document.getElementById("create-new-button");
+  createNewButton.addEventListener("click", async (e) => {
+    e.preventDefault();
+    const data = new FormData(createNewForm);
+    const formObject = Object.fromEntries(data);
+    if (validateString(formObject.name)) {
+      const res = await fetch("/api/createNew", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          objectId: `${formObject.type}:${formObject.name}`,
+        }),
+      });
+      const resData = await res.json();
+      if (!res.ok) {
+        createNewErrorMsg.innerText = resData.message;
+      } else {
+        createNewForm.reset();
+        createNewModal.close();
+        await renderFileListForUSer(currentUser.id);
+      }
+    } else {
+      createNewErrorMsg.innerText =
+        'Please only use letters, numbers and symbols like: ".-_"';
+    }
+  });
 
   const adminResponse = await fetch("/api/isAdmin", { credentials: "include" });
   const isadmin = await adminResponse.json();
@@ -121,12 +166,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
     const { files } = await res.json();
 
-    const rButton = document.getElementById("UploadNewbtn");
-    rButton.innerText = "back";
-    rButton.addEventListener("click", () => {
-      renderAdminUSerList();
-    });
-
     renderFiles(files);
   }
 
@@ -142,9 +181,20 @@ document.addEventListener("DOMContentLoaded", async () => {
         listItem.dataset.fileId = file.objectId;
         listItem.dataset.relations = file.relations;
 
+        const fileType = file.objectId.split(":")[0];
         const icon = document.createElement("i");
         icon.className = "material-icons type";
-        icon.innerText = "article";
+        switch (fileType) {
+          case "folder":
+            icon.innerText = "folder";
+            break;
+          case "file":
+            icon.innerText = "article";
+            break;
+          default:
+            icon.innerText = "question_mark";
+            break;
+        }
 
         const itemTitle = document.createElement("div");
         itemTitle.className = "item-title";
@@ -178,13 +228,6 @@ document.addEventListener("DOMContentLoaded", async () => {
       });
     }
   }
-
-  // old version
-
-  //const res = await fetch("/files", {
-  //  credentials: "include",
-  //});
-  //const { files } = await res.json();
 
   let selectedFile;
 
@@ -262,27 +305,17 @@ document.addEventListener("DOMContentLoaded", async () => {
     fileDetailsModal.showModal();
   });
 
-const createOption = document.getElementById("create-option");
-const modal_container = document.getElementById("modal_container");
-const close12 = document.getElementById("close12");
- 
-createOption.addEventListener('click', () => {
-  modal_container.classList.add("show");
+  const createOption = document.getElementById("create-option");
+  const modal_container = document.getElementById("modal_container");
+  const close12 = document.getElementById("close12");
 
-});
+  createOption.addEventListener("click", () => {
+    modal_container.classList.add("show");
+  });
 
-
-close12.addEventListener('click', () => {
-  modal_container.classList.remove("show");
-
-});
-
-
-
-
-
-
-
+  close12.addEventListener("click", () => {
+    modal_container.classList.remove("show");
+  });
 
   console.log(files);
 });
@@ -365,57 +398,32 @@ const renderMembers = async (fileId) => {
   }
 };
 
-
-
-
-
-
-
 // Create folder button
-  document.getElementById("confirm-create-folder").addEventListener("click", async () => {
-    const folderName = document.getElementById("folder-name-input").value;
-    const folderError = document.getElementById("folder-error");
-    
-    if (!folderName) {
-  folderError.innerText = "Please enter a folder name.";
-  return;
-}
+// document
+//   .getElementById("confirm-create-folder")
+//   .addEventListener("click", async () => {
+//     const folderName = document.getElementById("folder-name-input").value;
+//     const folderError = document.getElementById("folder-error");
 
-    const res = await fetch("/api/newFolder", {
-      method: "POST",
-      credentials: "include",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ folderName: folderName.toLowerCase() })
-    });
+//     if (!folderName) {
+//       folderError.innerText = "Please enter a folder name.";
+//       return;
+//     }
 
-    if (res.ok) {
-    modal_container.classList.remove("show");
-document.getElementById("folder-name-input").value = "";
-folderError.innerText = "";
-location.reload();
-    } else {
-      const data = await res.json();
-      alert(data.message);
-    }
-  });
+//     const res = await fetch("/api/newFolder", {
+//       method: "POST",
+//       credentials: "include",
+//       headers: { "Content-Type": "application/json" },
+//       body: JSON.stringify({ folderName: folderName.toLowerCase() }),
+//     });
 
-
-
-
-
-
-
-
-
-
-/*
-<div class="listitem">
-  <i class="material-icons type">article</i>
-  <div class="item-title">
-    <h3>Project.pdf</h3>
-    <p>Updated by User - 2 Hours ago</p>
-  </div>
-  <div class="relation">OWNER</div>
-  <a href="#"><i class="material-icons">more_vert</i></a>
-</div>
-*/
+//     if (res.ok) {
+//       modal_container.classList.remove("show");
+//       document.getElementById("folder-name-input").value = "";
+//       folderError.innerText = "";
+//       location.reload();
+//     } else {
+//       const data = await res.json();
+//       alert(data.message);
+//     }
+//   });

--- a/src/public/js/utils.js
+++ b/src/public/js/utils.js
@@ -1,0 +1,4 @@
+export const validateString = (str) => {
+  const regex = /^[a-zA-Z][\w.-]{1,15}$/;
+  return regex.test(str);
+};

--- a/src/public/pages/dashboard/index.html
+++ b/src/public/pages/dashboard/index.html
@@ -61,28 +61,14 @@
         <div id="files" class="page">
           <h1 id="allFilesHeader">All Files</h1>
           <div class="pageHeader">
-            <p id="allFIlesHeaderText">Here you will find an overview of all your files</p>
+            <p id="allFIlesHeaderText">
+              Here you will find an overview of all your files
+            </p>
             <button class="btn-lift" id="UploadNewbtn">
               <i class="material-icons">add</i>Upload New
             </button>
 
-            <button id="create-option">Create Folder</button>
-          </div>
-          <div class="modal-container" id="modal_container">
-            <div class="modal2">
-              <h1>Create Folder</h1>
-              <input
-                type="text"
-                id="folder-name-input"
-                placeholder="Folder name..."
-              />
-              <p id="folder-error" style="color: red"></p>
-
-              <div>
-                <button id="confirm-create-folder">Create</button>
-                <button id="close12">Close</button>
-              </div>
-            </div>
+            <!-- <button id="create-option">Create Folder</button> -->
           </div>
           <div id="filesList">
             <!-- <div class="listitem">
@@ -151,11 +137,35 @@
                 </div>
               </div>
               <div id="modal-buttons">
-                <button id="cancel-modal">Cancel</button>
+                <button id="cancel-modal" class="cancel-modal">Cancel</button>
                 <div></div>
                 <button class="btn-lift">Save Changes</button>
               </div>
             </div>
+          </dialog>
+          <dialog id="create-new">
+            <div class="create-new-modal">
+              <h2>Create a new file</h2>
+              <form id="create-new-form">
+                <input
+                name="name"
+                  type="text"
+                  id="new-name-input"
+                  placeholder="Write the name of the file/foler/group"
+                />
+                <select name="type" id="new-type-select" class="select-new-type">
+                  <option value="file">File</option>
+                  <option value="folder">Folder</option>
+                  <option value="group">Group</option>
+                </select>
+                <div class="create-new-buttons">
+                  <button id="create-new-cancel" class="cancel-modal">Cancel</button>
+                  <span></span>
+                  <button id="create-new-button" class="btn-lift">Create</button>
+                </span>
+              </form>
+            </div>
+            <p id="create-new-error" style="text-align: center; color: red;"></p>
           </dialog>
         </div>
         <div id="documents" class="page">

--- a/src/routes/access.js
+++ b/src/routes/access.js
@@ -93,7 +93,7 @@ class AccessControl {
    * @memberof AccessControl
    */
   async _expand(subjectId, objectId) {
-    this.db.read();
+    await this.db.read();
     const { byObject, bySubject } = this.db.data.tupleStore;
 
     const discoveredRelations = new Set();
@@ -198,8 +198,8 @@ class AccessControl {
     return relatedUsers;
   }
 
-  addTuple(subjectId, relation, objectId) {
-    this.db.read();
+  async addTuple(subjectId, relation, objectId) {
+    await this.db.read();
     const entryByObject = { subjectId, relation };
     const entryBySubject = { relation, objectId };
 
@@ -230,15 +230,15 @@ class AccessControl {
       this.db.data.tupleStore.bySubject[subjectId].push(entryBySubject);
     } else
       console.error(
-        "Tried to add a tupple to the bySubject database that already exists",
+        "Tried to add a tuple to the bySubject database that already exists",
       );
 
-    this.db.write();
+    await this.db.write();
   }
 
   // This function is maybe a WIP, debating on whether the effeciency of .filter() is fine in this case
-  deleteTuple(subjectId, relation, objectId) {
-    this.db.read();
+  async deleteTuple(subjectId, relation, objectId) {
+    await this.db.read();
 
     // 1. Remove from the byObject index
     if (this.db.data.tupleStore.byObject[objectId]) {
@@ -266,7 +266,7 @@ class AccessControl {
       }
     }
 
-    this.db.write();
+    await this.db.write();
   }
 }
 


### PR DESCRIPTION
Introduce a generic "create new" feature and refactor access control to be asynchronous. Changes include:

- Add POST /api/createNew in src/app.js to create folder/file/group tuples (with authentication and conflict handling) and remove the old /api/newFolder endpoint.
- Make accessControl methods async (addTuple, deleteTuple) and ensure db.read()/db.write() are awaited; update callers in app.js accordingly to await these operations.
- Add client-side validation helper src/public/js/utils.js (validateString) and wire it into the dashboard UI.
- Implement a create-new modal in the dashboard: new HTML dialog, JS handlers to submit to /api/createNew, UI/UX tweaks (cancel, reset, re-render file list) and dynamic icons per object type.
- CSS updates for modal/button styling and new create-new modal layout in src/public/css/dashboard.css.
- Cleanup and remove legacy/commented folder-creation code and adjust modal show/hide behavior.
- Update data/db.json tuples (rename/reassign some folder/file entries) to reflect test data changes.

Overall this adds a reusable create flow and improves data consistency by awaiting DB operations in the access control layer.